### PR TITLE
fix: 결승전 선택 시 결과 화면으로 자동 전환되도록 수정

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,21 +1,19 @@
 import streamlit as st
 
-for key in list(st.session_state.keys()):
-    del st.session_state[key]
-
 st.set_page_config(page_title="🍽️ 음식 이상형 월드컵", page_icon="🥘")
 
 st.title("🏠 음식 월드컵 시작하기")
 
+# ✅ 선택 라운드
 round_options = [4, 8, 16]
 selected_round = st.selectbox("플레이할 라운드를 선택하세요:", round_options)
 
+# ✅ 게임 시작 버튼
 if st.button("게임 시작"):
+    # ✅ 세션 전부 초기화
+    for key in list(st.session_state.keys()):
+        del st.session_state[key]
+
+    # ✅ 선택된 라운드만 다시 세팅
     st.session_state.round = selected_round
-    st.session_state.winner = {}
-
     st.switch_page("pages/main.py")
-
-
-
-    

--- a/pages/main.py
+++ b/pages/main.py
@@ -1,41 +1,39 @@
 import streamlit as st
 import random
 from game_logic import create_brackets, match_candidates
-import time 
+import time
 import os
 
-
-# food_images 폴더 경로
+# 이미지 폴더 설정
 image_folder = "food_images"
-
-# 이미지 파일 목록 가져오기
 image_files = [f for f in os.listdir(image_folder) if f.endswith(".jpg")]
 
-# candidates 리스트 생성
 candidates = [
     {"name": os.path.splitext(img)[0], "image": f"{image_folder}/{img}"}
     for img in image_files
 ]
 
-# 예시 라운드 수 선택 
-round_num = st.session_state.round 
+# 라운드 수 확인 (없으면 안내)
+if "round" not in st.session_state:
+    st.warning("홈 화면에서 라운드를 먼저 선택해 주세요.")
+    st.stop()
 
+round_num = st.session_state.round
 
-
-# 세션 초기화 
+# 초기 세션 상태 설정
 if "bracket" not in st.session_state:
     st.session_state.bracket = create_brackets(round_num, candidates)
     st.session_state.matchups = match_candidates(st.session_state.bracket)
     st.session_state.round_index = 0
     st.session_state.selected = []
     st.session_state.current_round = round_num
-    st.session_state.current_round_name = f"{round_num}강"
 
-# 현재 라운드 정보 업데이트
-st.session_state.current_round_name = "결승전" if st.session_state.current_round == 2 else f"{st.session_state.current_round}강"
+# 라운드명 설정
+st.session_state.current_round_name = (
+    "결승전" if st.session_state.current_round == 2 else f"{st.session_state.current_round}강"
+)
 
 st.subheader(f"{st.session_state.current_round_name} - {st.session_state.round_index + 1}번째 경기")
-
 
 # 경기 진행
 if st.session_state.round_index < len(st.session_state.matchups):
@@ -46,31 +44,34 @@ if st.session_state.round_index < len(st.session_state.matchups):
         st.session_state.selected.append(winner)
         st.session_state.round_index += 1
 
-        if st.session_state.round_index >= len(st.session_state.matchups):  # 라운드 종료 시
-            if len(st.session_state.selected) == 1:  
+        # 현재 라운드 종료 시
+        if st.session_state.round_index >= len(st.session_state.matchups):
+            if len(st.session_state.selected) == 1:
+                # ✅ 결승전 끝나면 바로 결과 페이지로 전환
                 st.session_state.bracket = st.session_state.selected
+                st.session_state.winner = st.session_state.selected[0]
+                st.switch_page("pages/game_result.py")
 
-            else: 
+            else:
+                # 다음 라운드 세팅
                 st.session_state.bracket = st.session_state.selected
                 st.session_state.matchups = match_candidates(st.session_state.bracket)
                 st.session_state.selected = []
                 st.session_state.round_index = 0
-                st.session_state.current_round //= 2  # 다음 라운드로 이동
-        
-        time.sleep(0.3)  
+                st.session_state.current_round //= 2
+
+        time.sleep(0.3)
         st.rerun()
 
-    # 왼쪽 후보
+    # 왼쪽 음식
     with col1:
         st.image(pair[0]['image'], use_container_width=True)
         if st.button(pair[0]['name']):
             select_winner(pair[0])
 
-    # 오른쪽 후보 
+    # 오른쪽 음식 (있을 경우만)
     if len(pair) > 1:
         with col2:
             st.image(pair[1]['image'], use_container_width=True)
             if st.button(pair[1]['name']):
                 select_winner(pair[1])
-
-# {st.session_state.bracket[0]['name']} # 최종 우승 

--- a/pages/rank_result.py
+++ b/pages/rank_result.py
@@ -4,6 +4,7 @@ import base64
 import json
 from math import ceil
 
+# 이미지 base64 변환 함수
 def image_to_base64(path):
     try:
         with open(path, "rb") as img_file:
@@ -11,6 +12,7 @@ def image_to_base64(path):
     except:
         return None
 
+# 랭킹 데이터 불러오기
 def load_ranking_from_file(filename="ranking_data.json"):
     try:
         with open(filename, "r", encoding="utf-8") as f:
@@ -18,21 +20,23 @@ def load_ranking_from_file(filename="ranking_data.json"):
     except FileNotFoundError:
         return {}
 
+# 📌 타이틀 + 홈 버튼
 col_title, col_home = st.columns([6, 1])
 with col_title:
     st.title("🏆 음식 인기 순위표")
 with col_home:
     st.page_link("app.py", label=" ", icon="🏠", use_container_width=True)
 
-
+# 데이터 로드
 ranking = load_ranking_from_file()
-
 if not ranking:
     st.warning("랭킹 데이터가 없습니다. 게임을 먼저 진행해 주세요.")
     st.stop()
 
+# 정렬
 sorted_items = sorted(ranking.items(), key=lambda x: x[1]["count"], reverse=True)
 
+# 페이지네이션 설정
 ITEMS_PER_PAGE = 5
 total_items = len(sorted_items)
 total_pages = ceil(total_items / ITEMS_PER_PAGE)
@@ -44,13 +48,15 @@ page = st.session_state.current_page
 start = (page - 1) * ITEMS_PER_PAGE
 end = start + ITEMS_PER_PAGE
 paginated_items = sorted_items[start:end]
-
 total_count = sum([v["count"] for _, v in ranking.items()])
+
 start_rank = start + 1
 end_rank = min(end, total_items)
 
+# 순위 표시
 st.markdown(f"### 🧾 음식 순위 ({start_rank}위 ~ {end_rank}위)")
 
+# 테이블 HTML
 table_html = f"""
 <style>
 table {{
@@ -89,7 +95,6 @@ for i, (name, data) in enumerate(paginated_items, start=start + 1):
       </div>
     </div>
     """
-
     table_html += f"""
     <tr>
         <td>{i}</td>
@@ -104,14 +109,17 @@ table_html += "</table>"
 
 components.html(table_html, height=650, scrolling=True)
 
+# 페이지 이동 버튼
 col1, col_spacer, col2 = st.columns([1, 5, 1])
 with col1:
     st.button("⬅️ 이전", disabled=(page <= 1), on_click=lambda: st.session_state.__setitem__('current_page', page - 1))
 with col2:
     st.button("다음 ➡️", disabled=(page >= total_pages), on_click=lambda: st.session_state.__setitem__('current_page', page + 1))
 
+# 페이지 번호 표시
 st.markdown(f"<div style='text-align: center; color: gray; font-size: 14px;'>페이지 {page} / {total_pages}</div>", unsafe_allow_html=True)
 
+# 홈으로 돌아가기
 if st.button("🏠 홈으로 가기"):
     for key in list(st.session_state.keys()):
         del st.session_state[key]

--- a/ranking_data.json
+++ b/ranking_data.json
@@ -1,18 +1,26 @@
 {
-  "떡볶이": {
-    "count": 26,
-    "image_url": "./img/떡볶이.png"
+  "닭갈비": {
+    "count": 2,
+    "image_url": "food_images/닭갈비.jpg"
   },
-  "치킨": {
-    "count": 3,
-    "image_url": "./img/치킨.png"
-  },
-  "피자": {
+  "파스타": {
     "count": 1,
-    "image_url": "./img/피자.png"
+    "image_url": "food_images/파스타.jpg"
   },
-  "삼겹살": {
-    "count": 5,
-    "image_url": "./img/삼겹살.png"
+  "쌀국수": {
+    "count": 1,
+    "image_url": "food_images/쌀국수.jpg"
+  },
+  "오징어볶음": {
+    "count": 1,
+    "image_url": "food_images/오징어볶음.jpg"
+  },
+  "나시고랭": {
+    "count": 1,
+    "image_url": "food_images/나시고랭.jpg"
+  },
+  "그린 커리": {
+    "count": 1,
+    "image_url": "food_images/그린 커리.jpg"
   }
 }


### PR DESCRIPTION
## #️⃣연관된 이슈
#13 

## 📝작업 내용
- 게임 진행(main.py) 중 결승 라운드에서 음식 하나가 선택되면,
  - 해당 음식을 `st.session_state.winner`에 저장
  - 즉시 `st.switch_page("pages/game_result.py")`를 호출하여 결과 화면으로 자동 전환되도록 수정
- 이전에는 결승 음식이 화면에 잠깐 노출되고 rerun되며 UX 흐름이 어색했으나,
  이번 수정으로 자연스럽게 결과 화면으로 연결됨

## 💬리뷰 요구사항
- 결승 라운드에서 최종 음식 선택 시 바로 결과 화면으로 이동되는지 확인 부탁드립니다.
- `st.session_state.winner` 값이 정상적으로 저장되고, `game_result.py`에서 잘 참조되는지 함께 체크해 주세요.